### PR TITLE
Use SELF instead of INPUTS(0) in pin lock contracts

### DIFF
--- a/grantorBeneficiaryPinLock.md
+++ b/grantorBeneficiaryPinLock.md
@@ -24,7 +24,7 @@ _Despite the additional proof `grantorPk || beneficiaryPk`, note that this contr
 Code
 ----------
 
-#### [Click Here To Run The Code Via The Ergo Playground](https://scastie.scala-lang.org/wGP2oQ3ZQSSV5dqhOn7auA)
+#### [Click Here To Run The Code Via The Ergo Playground](https://scastie.scala-lang.org/vhkNicsSSgaNrFYtSQWQnw)
 
 ```scala
 import org.ergoplatform.compiler.ErgoScalaCompiler._
@@ -89,12 +89,12 @@ println("-----------")
 // Note that we use parentheses to enforce this one-of-two signature AND the following pin check.
 // Without parentheses, the grantor would be able to withdraw funds without the pin.
 
-// sigmaProp(INPUTS(0).R4[Coll[Byte]].get == blake2b256(OUTPUTS(0).R4[Coll[Byte]].get))
+// sigmaProp(SELF.R4[Coll[Byte]].get == blake2b256(OUTPUTS(0).R4[Coll[Byte]].get))
 // Please refer to simple pin lock contract for details about this expression
 // that checks the hash of the pin number.
 
 val pinLockScript = s"""
-  (grantorPk || beneficiaryPk) && sigmaProp(INPUTS(0).R4[Coll[Byte]].get == blake2b256(OUTPUTS(0).R4[Coll[Byte]].get))
+  (grantorPk || beneficiaryPk) && sigmaProp(SELF.R4[Coll[Byte]].get == blake2b256(OUTPUTS(0).R4[Coll[Byte]].get))
 """.stripMargin
 
 // Compile a tailor-made contract with a `Map` of key to values required by pinLockScript

--- a/pinLockContract.md
+++ b/pinLockContract.md
@@ -5,7 +5,7 @@ Pin Lock Contract
 * Created: October 2 2020
 * License: CC0
 * Difficulty: Beginner
-* Ergo Playground Link: [Pin Lock Contract](https://scastie.scala-lang.org/KdWtOMjrTx2zb7wr2shPAA)
+* Ergo Playground Link: [Pin Lock Contract](https://scastie.scala-lang.org/FBQnxS8iQBqrt8MM2dykLw)
 
 Description
 ----------
@@ -19,7 +19,7 @@ Do note, this contract is purely intended to be used as an educational example. 
 
 Code
 ----------
-#### [Click Here To Run The Code Via The Ergo Playground](https://scastie.scala-lang.org/KdWtOMjrTx2zb7wr2shPAA)
+#### [Click Here To Run The Code Via The Ergo Playground](https://scastie.scala-lang.org/FBQnxS8iQBqrt8MM2dykLw)
 
 ```scala
 
@@ -39,7 +39,7 @@ import scorex.crypto.hash.{Blake2b256}
 // in R4 of the output box as cleartext and hashed to check against
 // the stored hash in the input box R4.
 val pinLockScript = s"""
-  sigmaProp(INPUTS(0).R4[Coll[Byte]].get == blake2b256(OUTPUTS(0).R4[Coll[Byte]].get))
+  sigmaProp(SELF.R4[Coll[Byte]].get == blake2b256(OUTPUTS(0).R4[Coll[Byte]].get))
 """.stripMargin
 val pinLockContract = ErgoScriptCompiler.compile(Map(), pinLockScript)
 


### PR DESCRIPTION
Explained in #21, the current pin lock contracts allow you to spend from the locked box even if pre-image is not known to you. It's possible to do so by just creating a new box with R4 == hash(message that you know), and having the first input of spending transaction be this input instead of pin lock box